### PR TITLE
Create IconCard component

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ npm run lint
   - `components`: contains reusable components
   - `router`: contains the routes to the pages of the website
   - `views`: contains the pages of the website
+  - `App.vue` : contains the layout and global styles of the website.
 
 The data that will be used in reusable components, such as cards, will be in `src/assets/data/` so it's easier to import them to the `src/views` files as one or few imports. Also, these are the information that will most likely be updated every year, so only having to go to `src/assets/data/` to update information allows this website to be easier to maintain. Some texts that aren't in `src/assets/data` will be on their own `src/views` files, and this will be the case if the information is only a few lines, can't be grouped meaningfully, won't be updated yearly, or aren't used in reusable components.
 

--- a/wics-website-vue/src/App.vue
+++ b/wics-website-vue/src/App.vue
@@ -39,8 +39,10 @@ body {
 }
 
 .main-view {
-  flex: 1; 
+  flex: 1;
 }
+
+/* global style for views */
 
 @media (min-width: 320px) {
   .view-container {
@@ -57,4 +59,56 @@ body {
     padding-right: 10rem;
   }
 }
+
+/***************************/
+
+/* global style for card components */
+
+.card-top {
+  background-color: var(--color-background-lighter_blue);
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+  height: 34px;
+  border-bottom: 2px solid var(--color-border-darker_blue);
+}
+
+.card-container {
+  width: 100%;
+  border-radius: 12px;
+  border: 2px solid var(--color-border-darker_blue);
+}
+
+/***************************/
+
+/* global style for button and psuedo-button elements, excluding navigation bar */
+
+.button {
+  text-decoration: none;
+  background-color: var(--color-background-lightest_blue);
+  color: var(--color-text-dark);
+
+  transition: 0.2s;
+  padding: 4px;
+  padding-left: 10px;
+  padding-right: 10px;
+
+  border: 2px solid var(--color-border-dark);
+  border-radius: 20px;
+
+  cursor: pointer;
+}
+
+@media (hover: hover) {
+  .button:hover {
+    background-color: var(--color-background-blue-hover);
+    color: var(--color-text-light);
+  }
+}
+
+.button:active {
+  background-color: var(--color-background-dark-hover);
+  color: var(--color-text-light);
+}
+
+/***************************/
 </style>

--- a/wics-website-vue/src/App.vue
+++ b/wics-website-vue/src/App.vue
@@ -76,6 +76,8 @@ body {
   width: 100%;
   border-radius: 12px;
   border: 2px solid var(--color-border-darker_blue);
+
+  word-break: break-word;
 }
 
 /***************************/

--- a/wics-website-vue/src/assets/base.css
+++ b/wics-website-vue/src/assets/base.css
@@ -8,6 +8,7 @@
     --color-wics-regular-blue: #6097c9;
     --color-wics-light-blue: #88b9e3;
     --color-wics-lighter-blue: #c6dbed;
+    --color-wics-lightest-blue: #d9e7f8;
 
     /* this blue is close to regular blue but it passes WCAG AA with #fefefe */
     --color-wics-aa-blue: #3C77AF;
@@ -15,18 +16,23 @@
 
     /* naming convention: [color/font]-[css property]-[color/shade]-[state] */
     --color-background-light: var(--color-wics-light-white);
+    --color-background-lighter_blue: var(--color-wics-lighter-blue);
+    --color-background-lightest_blue: var(--color-wics-lightest-blue);
     --color-background-blue: var(--color-wics-aa-blue);
     --color-background-dark: var(--color-wics-darker-blue);
-    --color-background-lighter-blue: var(--color-wics-lighter-blue);
 
     --color-background-light-hover: var(--color-wics-light-blue);
+    --color-background-blue-hover: var(--color-wics-aa-blue);
     --color-background-dark-hover: var(--color-wics-dark-blue);
 
     --color-text-dark: var(--color-wics-darker-blue);
     --color-text-light: var(--color-wics-light-white);
     --color-text-gray: var(--color-wics-dark-gray);
 
-    --color-border-dark: var(--color-wics-darker-blue);
+    --color-border-dark: var(--color-wics-dark-blue);
+    --color-border-darker_blue: var(--color-wics-darker-blue);
+
+    --color-svg-dark_blue: var(--color-wics-dark-blue);
 
     --color-shadow-dark: var(--color-wics-darker-blue);
 

--- a/wics-website-vue/src/components/CardComponent.vue
+++ b/wics-website-vue/src/components/CardComponent.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="card-container">
-        <div class="top"></div>
+        <div class="card-top"></div>
         <div class="main">
             <img class="card-img" :src="image" />
-            <h1 class="title">{{ title }}</h1>      
+            <h1 class="title">{{ title }}</h1>
             <p class="body">{{ description }}</p>
         </div>
     </div>
@@ -11,32 +11,18 @@
 
 <script>
 export default {
-  name: 'CardComponent',
-  props: {
-    image: String,
-    title: String,
-    description: String,
-  }
+    name: 'CardComponent',
+    props: {
+        image: String,
+        title: String,
+        description: String,
+    }
 }
 </script>
 
 <style scoped>
 * {
     box-sizing: border-box;
-}
-
-.card-container {
-    width: 100%;
-    border-radius: 12px;
-    border: 2px solid var(--color-border-dark);
-}
-
-.top {
-    background-color: var(--color-background-lighter-blue);
-    border-top-left-radius: inherit;
-    border-top-right-radius: inherit;
-    height: 34px;
-    border-bottom: 2px solid var(--color-border-dark);
 }
 
 .main {
@@ -47,8 +33,8 @@ export default {
 }
 
 .card-img {
-    width: 100%;  
-    height: 100%; 
+    width: 100%;
+    height: 100%;
     object-fit: cover;
     display: block;
     padding: 0;

--- a/wics-website-vue/src/components/IconCard.vue
+++ b/wics-website-vue/src/components/IconCard.vue
@@ -20,7 +20,7 @@ const props = defineProps({
 <style scoped>
 .social {
     display: flex;
-    justify-content: center;
+    padding-left: 20px;
 
     color: var(--color-text-dark);
 }
@@ -30,18 +30,18 @@ const props = defineProps({
     flex-direction: column;
     gap: 5px;
     justify-content: center;
-    align-content: center;
 
     text-align: start;
 
     /* accounts for the space in an svg */
     padding-right: 30px;
-
 }
 
 svg {
     width: 150px;
     height: 150px;
+    min-width: 100px;
+    min-height: 100px;
     fill: var(--color-svg-dark_blue);
 }
 </style>

--- a/wics-website-vue/src/components/IconCard.vue
+++ b/wics-website-vue/src/components/IconCard.vue
@@ -1,0 +1,47 @@
+<template>
+    <div class="card-container">
+        <div class="card-top"></div>
+        <div class="social">
+            <component :is="socialMedia?.svgIcon"></component>
+            <div class="description">
+                <h4>{{ socialMedia?.name }}</h4>
+                <a class="button" :href="socialMedia?.link" target="_blank">{{ socialMedia?.username }}</a>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+const props = defineProps({
+    socialMedia: { type: Object }
+})
+</script>
+
+<style scoped>
+.social {
+    display: flex;
+    justify-content: center;
+
+    color: var(--color-text-dark);
+}
+
+.description {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    justify-content: center;
+    align-content: center;
+
+    text-align: start;
+
+    /* accounts for the space in an svg */
+    padding-right: 30px;
+
+}
+
+svg {
+    width: 150px;
+    height: 150px;
+    fill: var(--color-svg-dark_blue);
+}
+</style>

--- a/wics-website-vue/src/components/MemberCard.vue
+++ b/wics-website-vue/src/components/MemberCard.vue
@@ -7,7 +7,7 @@
                 <p class="position"><i>{{ member?.position }}</i></p>
                 <div class="tag">
                     <p>{{ member?.memberType }}</p>
-                    <p>{{ member?.pronouns}}</p>
+                    <p>{{ member?.pronouns }}</p>
                 </div>
             </div>
         </div>
@@ -37,7 +37,7 @@ const props = defineProps({
 
         height: fit-content;
         padding: 3%;
-        border: 2px solid var(--color-border-dark);
+        border: 2px solid var(--color-border-darker_blue);
         border-radius: 30px;
         margin: 3%;
 
@@ -68,7 +68,7 @@ const props = defineProps({
 
         height: 100%;
         padding: 2%;
-        border: 2px solid var(--color-border-dark);
+        border: 2px solid var(--color-border-darker_blue);
         border-radius: 30px;
         margin: 2%;
 


### PR DESCRIPTION
Closes #53 

Create IconCard component whose pseudo button styles were added to App.vue as a global style. 
Modify README.md to clarify that global styles like card-container and view-container will be in App.vue. 
Add comments in App.vue to clarify which part is a global/shared style. 
Move card styles to App.vue to reuse it in both card and icon card components. 
Modify base.css to use underscore instead of dash for css variables when the naming convention isn't followed. 
Add new variables to base.css.

(Some files were changed and done in this PR as they're related to the IconCard component. Some were automatically formatted.)

IconCard in mobile:
![image](https://github.com/user-attachments/assets/c2bb3bc1-371c-4915-b070-bc39c861acb9)

IconCard in desktop: (the width can be adjusted through whichever vue file will be using this component)
![image](https://github.com/user-attachments/assets/82577ebb-6e2e-42d7-b5ab-80d4f35beb02)

IconCard with long text overflow:
![image](https://github.com/user-attachments/assets/400dcf2f-fa59-4b10-ae5e-f18028aa4842)

