### PR TITLE
Give credit to svg creators properly

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 # Website License 
-This work is licensed under a Creative Commons Attribute-NonCommercial-ShareAlike 4.0 International License. For more information, please visit the following link: https://creativecommons.org/licenses/by-nc-sa/4.0/
+© 2025 University of Manitoba Women in Computer Science. All Rights Reserved. This work is licensed under a Creative Commons Attribute-NonCommercial-ShareAlike 4.0 International License. For more information, please visit the following link: https://creativecommons.org/licenses/by-nc-sa/4.0/
 
 # SVG Assets License
 The SVG assets used in this website are licensed under the MIT License.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,36 @@
+# Website License 
+This work is licensed under a Creative Commons Attribute-NonCommercial-ShareAlike 4.0 International License. For more information, please visit the following link: https://creativecommons.org/licenses/by-nc-sa/4.0/
+
+# SVG Assets License
+The SVG assets used in this website are licensed under the MIT License.
+
+MIT License
+
+- EmailSVG, InstagramSVG: 
+  - Copyright (c) Kenan Gundogan (https://github.com/kenangundogan/fontisto)
+  - Modifications by WICS Website Committee include:
+    - Adjusted colors to match WICS' brand.
+    - Resized dimensions to fit website's design and to make it responsive.
+- GitHubSVG, LinkedInSVG: 
+  - Copyright (c) Gitlab (https://gitlab.com/gitlab-org/gitlab-svgs?ref=iconduck.com)
+  - Modifications by WICS Website Committee include:
+    - Adjusted colors to match WICS' brand.
+    - Resized dimensions to fit website's design and to make it responsive.
+- Menu Hamburger in NavBar.vue: 
+  - Copyright (c) jaynewey (https://github.com/jaynewey/charm-icons)
+  - Modifications by WICS Website Committee include:
+    - Adjusted colors to match WICS' brand.
+    - Resized dimensions to fit website's design and to make it responsive.
+    - Moved stroke style out of the svg and into the style part of the code.
+- X in NavBar.vue: 
+  - Copyright (c) hicon (https://hicon.me/)
+  - Modifications by WICS Website Committee include:
+    - Adjusted colors to match WICS' brand.
+    - Resized dimensions to fit website's design and to make it responsive.
+    - Moved stroke style out of the svg and into the style part of the code.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -21,13 +21,14 @@ MIT License
   - Modifications by WICS Website Committee include:
     - Adjusted colors to match WICS' brand.
     - Resized dimensions to fit website's design and to make it responsive.
-    - Moved stroke style out of the svg and into the style part of the code.
+    - Moved some stroke style out of the svg and into the style part of the code.
 - X in NavBar.vue: 
   - Copyright (c) hicon (https://hicon.me/)
   - Modifications by WICS Website Committee include:
     - Adjusted colors to match WICS' brand.
     - Resized dimensions to fit website's design and to make it responsive.
-    - Moved stroke style out of the svg and into the style part of the code.
+    - Moved some stroke style out of the svg and into the style part of the code.
+    - Made stroke bigger for better visibility.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,24 +8,24 @@ MIT License
 
 - EmailSVG, InstagramSVG: 
   - Copyright (c) Kenan Gundogan (https://github.com/kenangundogan/fontisto)
-  - Modifications by WICS Website Committee include:
-    - Adjusted colors to match WICS' brand.
+  - Modifications by UMWICS Website Committee include:
+    - Adjusted colors to match UMWICS' brand.
     - Resized dimensions to fit website's design and to make it responsive.
 - GitHubSVG, LinkedInSVG: 
-  - Copyright (c) Gitlab (https://gitlab.com/gitlab-org/gitlab-svgs?ref=iconduck.com)
-  - Modifications by WICS Website Committee include:
-    - Adjusted colors to match WICS' brand.
+  - Copyright (c) GitLab (https://gitlab.com/gitlab-org/gitlab-svgs?ref=iconduck.com)
+  - Modifications by UMWICS Website Committee include:
+    - Adjusted colors to match UMWICS' brand.
     - Resized dimensions to fit website's design and to make it responsive.
 - Menu Hamburger in NavBar.vue: 
   - Copyright (c) jaynewey (https://github.com/jaynewey/charm-icons)
-  - Modifications by WICS Website Committee include:
-    - Adjusted colors to match WICS' brand.
+  - Modifications by UMWICS Website Committee include:
+    - Adjusted colors to match UMWICS' brand.
     - Resized dimensions to fit website's design and to make it responsive.
     - Moved some stroke style out of the svg and into the style part of the code.
 - X in NavBar.vue: 
   - Copyright (c) hicon (https://hicon.me/)
-  - Modifications by WICS Website Committee include:
-    - Adjusted colors to match WICS' brand.
+  - Modifications by UMWICS Website Committee include:
+    - Adjusted colors to match UMWICS' brand.
     - Resized dimensions to fit website's design and to make it responsive.
     - Moved some stroke style out of the svg and into the style part of the code.
     - Made stroke bigger for better visibility.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 This is the repository for the website of Women in Computer Science (WICS) at the University of Manitoba. WICS is a student group supporting women and gender minorities in Computer Science. Our aim is to make computer science less intimidating and create a safe space for women and gender minorities to connect. This website is being built using Vue 3 Composition API and tested using Vitest. 
 
-## Website License 
-© 2025 University of Manitoba Women in Computer Science. All Rights Reserved. This work is licensed under a Creative Commons Attribute-NonCommercial-ShareAlike 4.0 International License. 
-
 ## Recommended Setup
 
 IDE: 

--- a/wics-website-vue/src/components/NavBar.vue
+++ b/wics-website-vue/src/components/NavBar.vue
@@ -11,12 +11,17 @@
 
             <div v-if="!navOptionsFit" class="menu-button">
                 <button @click="toggleNavOptionsDropdown">
-                    <svg v-if="!dropdownShown" viewBox="0 0 16 16" stroke-width="2" xmlns="http://www.w3.org/2000/svg"
+
+                    <!-- License: MIT. Made by jaynewey: https://github.com/jaynewey/charm-icons -->
+                    <svg v-if="!dropdownShown" viewBox="0 -1 16 16" stroke-width="2" xmlns="http://www.w3.org/2000/svg"
                         version="1.1">
                         <path d="m2.75 12.25h10.5m-10.5-4h10.5m-10.5-4h10.5" />
                     </svg>
-                    <svg v-else viewBox="0 0 24 24" stroke-width="3" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M12 12 7 7m5 5 5 5m-5-5 5-5m-5 5-5 5" />
+
+                    <!-- License: MIT. Made by hicon: https://hicon.me/ -->
+                    <svg v-else viewBox="-3 -4 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M19 5L5 19" stroke-width="3" />
+                        <path d="M5 5L19 19" stroke-width="3" />
                     </svg>
                 </button>
             </div>


### PR DESCRIPTION
Closes #72 

Create LICENSE.md to specify that the website is under CC license, while the SVGs are under MIT license. 
Remove license part in README.md as license already has a dedicated file for it. 
Use different SVG for navbar x as the license part isn't present and can't be found. 
Add comment for the license of hamburger icon.