### PR TITLE
Create CollageComponent.vue

### DIFF
--- a/wics-website-vue/src/components/CollageComponent.vue
+++ b/wics-website-vue/src/components/CollageComponent.vue
@@ -1,0 +1,54 @@
+<template>
+    <div class="collage-container">
+        <img v-for="item in content.images" :key="item?.position" :src="item.imageSrc" :alt="item.alt" />
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'CollageComponent',
+    props: {
+        content: Object
+    }
+}
+</script>
+
+<style scoped>
+.collage-container {
+    max-width: 800px;
+    margin-inline: auto;
+    display: grid;
+    gap: 0.5rem;
+    grid-template-areas: 
+    "one   one   five five five two  two"
+    "three three five five five four four";
+}
+
+.collage-container img {
+    width: 100%;
+    aspect-ratio: 1;
+    display: block;
+    object-fit: cover;
+    align-self: center;
+}
+
+.collage-container :nth-child(1) {
+    grid-area: one;
+}
+
+.collage-container :nth-child(2) {
+    grid-area: two;
+}
+
+.collage-container :nth-child(3) {
+    grid-area: three;
+}
+
+.collage-container :nth-child(4) {
+    grid-area: four;
+}
+
+.collage-container :nth-child(5) {
+    grid-area: five;
+} 
+</style>

--- a/wics-website-vue/src/components/CollageComponent.vue
+++ b/wics-website-vue/src/components/CollageComponent.vue
@@ -1,16 +1,28 @@
 <template>
-    <div class="collage-container">
-        <img v-for="item in content.images" :key="item?.position" :src="item.imageSrc" :alt="item.alt" />
+    <div class="collage-container" :class="collageFormationStyle">
+        <img v-for="item in images" :key="item?.position" :src="item.imageSrc" :alt="item.alt" />
     </div>
 </template>
 
-<script>
-export default {
-    name: 'CollageComponent',
-    props: {
-        content: Object
-    }
-}
+<script setup>
+import { computed } from 'vue';
+
+const name = "CollageComponent";
+
+defineOptions({
+    name: name,
+});
+
+const props = defineProps({
+    images: { type: Object }
+})
+
+/** 
+ * creates a BEM class name depending on how many images there are, 
+ * so the design of collage varies depending on the amount of images. 
+ */
+const collageFormationStyle = computed(() => "collage-container--formation-for-" + props.images?.length);
+
 </script>
 
 <style scoped>
@@ -19,9 +31,30 @@ export default {
     margin-inline: auto;
     display: grid;
     gap: 0.5rem;
-    grid-template-areas: 
-    "one   one   five five five two  two"
-    "three three five five five four four";
+}
+
+.collage-container--formation-for-5 {
+    grid-template-areas:
+        "one   one   five five five two  two"
+        "three three five five five four four";
+}
+
+.collage-container--formation-for-4 {
+    grid-template-areas:
+        "one   one   five five five two  two"
+        "three three five five five four four";
+}
+
+.collage-container--formation-for-3 {
+    grid-template-areas:
+        "one   one   two   two   three   three"
+        "one   one   two   two   three   three";
+}
+
+.collage-container--formation-for-2 {
+    grid-template-areas:
+        "one   one   two  two"
+        "one   one   two  two";
 }
 
 .collage-container img {
@@ -50,5 +83,5 @@ export default {
 
 .collage-container :nth-child(5) {
     grid-area: five;
-} 
+}
 </style>

--- a/wics-website-vue/src/components/CollageComponent.vue
+++ b/wics-website-vue/src/components/CollageComponent.vue
@@ -27,7 +27,7 @@ const collageFormationStyle = computed(() => "collage-container--formation-for-"
 
 <style scoped>
 .collage-container {
-    max-width: 800px;
+    width: 100%;
     margin-inline: auto;
     display: grid;
     gap: 0.5rem;


### PR DESCRIPTION
closes #19 

This is worked on by @mandy-gill and Ara! (Thus we can't review this PR)

Collage component takes in up to 5 images and presents those images differently depending on how many images are put in. The images should be taken in as an array of objects. The design for 3 images was changed as the one on Figma looks off. I designed it so I can say that :)

When reviewing this code, you can copy paste the code in my other comment into HomeView.vue. You can comment out the images and see the responsiveness etc.

2 images:
![image](https://github.com/user-attachments/assets/ac37c694-14ec-4dfd-be7d-9cd5c4a4db35)

3 images:
![image](https://github.com/user-attachments/assets/d9b8f9f3-dd6e-4709-95ac-9e05ee904c84)

4 images:
![image](https://github.com/user-attachments/assets/303e15ec-0340-4693-89fc-576acf556c0b)

5 images:
![image](https://github.com/user-attachments/assets/10fb550b-06b9-4b29-876a-95c7e06e869d)
