### PR TITLE
Fix bug on navbar

### DIFF
--- a/wics-website-vue/src/components/NavBar.vue
+++ b/wics-website-vue/src/components/NavBar.vue
@@ -144,6 +144,10 @@ a {
     cursor: pointer;
 }
 
+.nav-options {
+    -webkit-tap-highlight-color: transparent;
+}
+
 /* .router-link-active is a class from RouterLink */
 .nav-options a.router-link-active {
     background-color: var(--color-background-dark-hover);


### PR DESCRIPTION
Closes #15 

- Remove the blue background/highlight that appears when clicking the nav bar option in chrome mobile.

Now it's gone yay!
![image](https://github.com/user-attachments/assets/f43e85f4-2bbe-46dc-94d0-e02aa540ccba)
